### PR TITLE
fix: Results count for Airdrop List

### DIFF
--- a/apps/web/containers/UserClaimsTable.tsx
+++ b/apps/web/containers/UserClaimsTable.tsx
@@ -70,7 +70,7 @@ const UserClaimsTable: React.FC = () => {
               <span className="font-medium">{pageNumber * pageSize + 1}</span>{" "}
               to{" "}
               <span className="font-medium">
-                {pageNumber * pageSize + pageSize}
+                {pageNumber * pageSize + claims.length}
               </span>
             </p>
           </div>


### PR DESCRIPTION
Results count in Airdrop List was showing more results than were actually there when `claims.length !== PAGE_SIZE`. 
Fixed by using the length of the `claims` array.